### PR TITLE
added cca

### DIFF
--- a/pytorch-YOLOv4-master/tool/plateprocessing.py
+++ b/pytorch-YOLOv4-master/tool/plateprocessing.py
@@ -85,6 +85,7 @@ def find_boxes(thresh, drawplates, maxareathresh, minareathresh):
 			i = i + 1
 		idx = np.argsort(centroid)
 		cc = np.array(cc)[idx]
+		print(len(idx), len(centroid))
 		#centroid = np.array(centroid)[idx]
 		return thresh, cc
 	else:

--- a/yolov4_test.py
+++ b/yolov4_test.py
@@ -41,7 +41,13 @@ while True:
     finish = time.time()
     print('Predicted in %f seconds.' % (finish - start))
     # digitbox consists of image segment for each digit, which can be accessed as digitbox[i], where 'i' is the index of an element
-    plate_emnist, digitbox = plate_detect(img, boxes[0], drawplates = False, maxareathresh = 500, minareathresh = 10)
+    if(len(boxes[0]) > 0):
+        try:
+            plate_emnist, digitbox = plate_detect(img, boxes[0], drawplates = False, maxareathresh = 500, minareathresh = 10)
+        except:
+            continue
+    else:
+        continue
 
     result_img = plot_boxes_cv2(img, boxes[0], savename=False, class_names=class_names)
     cv2.imshow('Yolo demo', result_img)


### PR DESCRIPTION
Added bounding box detection for each set of connected white pixels in the segmented number plate in binary format. `drawplates = False` can be turned to `True` to plot the bounding boxes as well. `areathresh` is a parameter to filter out boxes based on its size. The function returns `digitbox` as a NumPy array with each row having coordinates as `[x1,y1,x2,y2]` where the first two indicate coordinates of the top left corner and the other two indicate the top right corner of a bounding box. 